### PR TITLE
Fix the markdownlint configuration

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,18 +1,16 @@
 {
-  // Enable all rules by default
-  "default": true,
-
-  // Disable line length check
-  "MD013": false,
-
-  // Allow duplicate headers in different nested sections
-  "MD024": {
-    "allow_different_nesting": true
-  },
-
-  // Allow inline HTML
-  "MD033": false,
-
-  // First line in a file doesn't need to be a top-level header
-  "MD041": false,
+    "config": {
+        // Enable all rules by default
+        "default": true,
+        // Disable line length check
+        "MD013": false,
+        // Allow duplicate headers in different nested sections
+        "MD024": {
+            "allow_different_nesting": true
+        },
+        // Allow inline HTML
+        "MD033": false,
+        // First line in a file doesn't need to be a top-level header
+        "MD041": false
+    }
 }


### PR DESCRIPTION
I had messed up the format of the configuration file, that's why the configuration wasn't applied. 