### PR TITLE
Document use of the colon operator

### DIFF
--- a/spec/lexical-analysis.md
+++ b/spec/lexical-analysis.md
@@ -302,7 +302,7 @@ The following symbolic or partially symbolic character sequences are treated as 
 ```fsgrammar
 token symbolic-keyword =
     let! use! do! yield! return!
-    | -> <-. : ( ) [ ] [< >] [| |] { }
+    | -> <- . : ( ) [ ] [< >] [| |] { }
     ' # :?> :? :> .. :: := ;; ; =
     _? ?? (*) <@ @> <@@ @@>
 ```
@@ -321,7 +321,7 @@ except where the sequence of characters is a symbolic keyword ([§](lexical-anal
 
 ```fsgrammar
 regexp first-op-char = !%&*+-./<=>@^|~
-regexp op-char = first-op-char |?
+regexp op-char = first-op-char | [?:]
 
 token quote-op-left =
     | <@ <@@
@@ -330,7 +330,7 @@ token quote-op-right =
     | @> @@>
 
 token symbolic-op =
-    |?
+    | ?
     | ?<-
     | first-op-char op-char *
     | quote-op-left
@@ -339,6 +339,9 @@ token symbolic-op =
 
 For example, `&&&` and `|||` are valid symbolic operators. Only the operators `?` and `?<-` may start with
 `?`.
+
+Use of `:` in symbolic operators is partially reserved. It may only be used in operators where the first character
+is `>` or where the first character after any number of leading `.` is `>` e.g. `>:` or `.>:`.
 
 The `quote-op-left` and `quote-op-right` operators are used in quoted expressions ([§](expressions.md#quoted-expressions)).
 
@@ -388,7 +391,7 @@ token unativeint = ( int | xint ) 'un'           For example, 34un
 token int64 = ( int | xint ) 'L'                 For example, 34L
 token uint64 = ( int | xint ) 'UL'               For example, 34UL
              | ( int | xint ) 'uL'               For example, 34uL
- 
+
 token float =
     int . int?
     int (. int?)? (e|E) (+|-)? int


### PR DESCRIPTION
The `:` operator became partially unreserved when https://github.com/dotnet/fsharp/pull/15923 was merged. 

Also tidies up some minor whitespace errors. 