### PR TITLE
Add missing prefix operators to Categorization of Symbolic Operators

### DIFF
--- a/spec/basic-grammar-elements.md
+++ b/spec/basic-grammar-elements.md
@@ -195,7 +195,7 @@ elsewhere in the table.
 
 ```fsgrammar
 infix-or-prefix-op :=
-    +, -, +., -., %, &, &&
+    +, -, +., -., %, %%, &, &&, ?+, ?-
 prefix-op :=
     infix-or-prefix-op
     ~ ~~ ~~~    (and any repetitions of ~)
@@ -211,7 +211,7 @@ infix-op :=
     ?
 ```
 
-The operators `+`, `-`, `+.`, `-.`, `%`, `%%`, `&`, `&&` can be used as both prefix and infix operators. When these
+The operators `+`, `-`, `+.`, `-.`, `%`, `%%`, `&`, `&&`, `?+`, `?-` can be used as both prefix and infix operators. When these
 operators are used as prefix operators, the tilde character is prepended internally to generate the
 operator name so that the parser can distinguish such usage from an infix use of the operator. For
 example, `-x` is parsed as an application of the operator `~-` to the identifier `x`. This generated name is


### PR DESCRIPTION
I noted that these prefix operators `%%` `?+` `?-` were missing from the listing. I don't think they correspond to an RFC so probably a historical omission. 