### PR TITLE
added comma to symbolic keyword list, removed quote-ops from symbolic operator list

### DIFF
--- a/spec/lexical-analysis.md
+++ b/spec/lexical-analysis.md
@@ -311,7 +311,7 @@ The following symbolic or partially symbolic character sequences are treated as 
 token symbolic-keyword =
     let! use! do! yield! return! match!
     | -> <- . : ( ) [ ] [< >] [| |] { }
-    ' # :?> :? :> .. :: := ;; ; =
+    ' # :?> :? :> .. :: := ;; ; , =
     _? ?? (*) <@ @> <@@ @@>
 ```
 
@@ -331,24 +331,14 @@ except where the sequence of characters is a symbolic keyword ([§](lexical-anal
 regexp first-op-char = !%&*+-./<=>@^|~
 regexp op-char = first-op-char | [?:]
 
-token quote-op-left =
-    | <@ <@@
-
-token quote-op-right =
-    | @> @@>
-
 token symbolic-op =
     | ?
     | ?<-
     | first-op-char op-char *
-    | quote-op-left
-    | quote-op-right
 ```
 
 For example, `&&&` and `|||` are valid symbolic operators. Only the operators `?` and `?<-` may start with
 `?`.
-
-The `quote-op-left` and `quote-op-right` operators are used in quoted expressions ([§](expressions.md#quoted-expressions)).
 
 For details about the associativity and precedence of symbolic operators in expression forms, see
 §4.4.

--- a/spec/lexical-analysis.md
+++ b/spec/lexical-analysis.md
@@ -312,7 +312,7 @@ token symbolic-keyword =
     let! use! do! yield! return! match!
     | -> <- . : ( ) [ ] [< >] [| |] { }
     ' # :?> :? :> .. :: := ;; ; , =
-    _? ?? (*) <@ @> <@@ @@>
+    _ ? ?? (*) <@ @> <@@ @@>
 ```
 
 The following symbols are reserved for future use:

--- a/spec/lexical-filtering.md
+++ b/spec/lexical-filtering.md
@@ -321,7 +321,7 @@ keywords:
 | _Namespace_ | The `namespace` keyword |
 | _Module_ | The `module` keyword |
 | _Member_ | The `member`, `abstract`, `default`, or `override` keyword, if the _Member_ context is not already active, because multiple tokens may be present.<br>- or -<br>`(` is the next token after the `new` keyword. This distinguishes the member declaration `new(x) = ... from the expression new x()` |
-| _Paren(token)_ | `(`, `begin`, `struct`, `sig`, `{`, `[`, `[\|`, or `quote-op-left` |
+| _Paren(token)_ | `(`, `begin`, `struct`, `sig`, `{`, `[`, `[\|`, `<@`, or `<@@` |
 | _MatchClauses_ | The `with` keyword in a _Try_ or _Match_ context immediately after a `function` keyword. |
 | _Vanilla_ | An otherwise unprocessed keyword in a _SeqBlock_ context. |
 
@@ -347,7 +347,8 @@ The following table lists the contexts that the compiler pops and the balancing 
 | `}` | `Paren({)` |
 | `]` | `Paren([)` |
 | `\|]` | `Paren([\|)` |
-| `quote-op-right` | `Paren(quote-op-left)` |
+| `@>` | `Paren(<@)` |
+| `@@>` | `Paren(<@@)` |
 
 ### Offside Tokens, Token Insertions, and Closing Contexts
 

--- a/spec/patterns.md
+++ b/spec/patterns.md
@@ -194,9 +194,9 @@ let Case1 = 1
 let Case2 = 100
 
 let result =
-    match 1 00 with
+    match 100 with
     | Case1 -> "Case1"
-    | Case2 -> "Case 2 "
+    | Case2 -> "Case2"
     | _ -> "Some other case"
 ```
 


### PR DESCRIPTION
The comma was completely missing.

quote-of-left / quote-op-right seem to be redundant in symbolic operators.

Also fixed a typo (conversion error) in chapter 7